### PR TITLE
docs: add safety warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # py3buddy
+
+**WARNING**: during a test of this project, our i-Buddy started to burn. Do not run this device unattended!
+
 Python 3 code to work with the iBuddy MSN figurine released under the MIT license.
 
 * py3buddy.py -- main file with class


### PR DESCRIPTION
The i-Buddy can overheat and burn, so we add a warning to the README not to run
the device unattended.

Refers to #4