### PR TITLE
Replace deprecated readfp() method

### DIFF
--- a/py3buddy/py3buddydbus.py
+++ b/py3buddy/py3buddydbus.py
@@ -65,10 +65,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddydbus.py
+++ b/py3buddy/py3buddydbus.py
@@ -65,10 +65,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddydemo.py
+++ b/py3buddy/py3buddydemo.py
@@ -124,10 +124,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddydemo.py
+++ b/py3buddy/py3buddydemo.py
@@ -124,10 +124,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddyearthquake.py
+++ b/py3buddy/py3buddyearthquake.py
@@ -104,10 +104,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddyearthquake.py
+++ b/py3buddy/py3buddyearthquake.py
@@ -104,10 +104,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddyearthquakedbus.py
+++ b/py3buddy/py3buddyearthquakedbus.py
@@ -108,10 +108,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddyearthquakedbus.py
+++ b/py3buddy/py3buddyearthquakedbus.py
@@ -108,10 +108,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddypidgin.py
+++ b/py3buddy/py3buddypidgin.py
@@ -62,10 +62,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddypidgin.py
+++ b/py3buddy/py3buddypidgin.py
@@ -62,10 +62,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddytwitterlike.py
+++ b/py3buddy/py3buddytwitterlike.py
@@ -60,10 +60,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-      config.read_file(configfile)
+        config.read_file(configfile)
     except Exception as e:
-      print(f"Cannot read configuration file: {e}", file=sys.stderr)
-      sys.exit(1)
+        print(f"Cannot read configuration file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():

--- a/py3buddy/py3buddytwitterlike.py
+++ b/py3buddy/py3buddytwitterlike.py
@@ -60,10 +60,10 @@ def main(argv):
     configfile = open(args.cfg, 'r')
 
     try:
-        config.readfp(configfile)
-    except Exception:
-        print("Cannot read configuration file", file=sys.stderr)
-        sys.exit(1)
+      config.read_file(configfile)
+    except Exception as e:
+      print(f"Cannot read configuration file: {e}", file=sys.stderr)
+      sys.exit(1)
 
     buddy_config = {}
     for section in config.sections():


### PR DESCRIPTION
The config file can now be read on versions of python newer than 3.8.